### PR TITLE
fix(docker): upgrade frontend Dockerfile node:18 → node:20 for Vite 8

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:18-alpine AS builder
+FROM node:20-alpine AS builder
 
 WORKDIR /app
 
-COPY package.json ./
+COPY package.json package-lock.json ./
 
-RUN npm install
+RUN npm ci
 
 COPY ./ .
 


### PR DESCRIPTION
## Fix: Frontend Docker build failure

### Problem
After merging PR #11 (vite 7→8 upgrade), the `Build & Push to Docker Hub` workflow fails at the **Build and push frontend** step.

**Root cause:** `frontend/Dockerfile` uses `node:18-alpine`, but **Vite 8 requires Node.js 20+**.

### Changes
- `node:18-alpine` → `node:20-alpine`
- Copy `package-lock.json` and use `npm ci` instead of `npm install` (reproducible builds)

### Verified
- ✅ `npm ci` installs cleanly with lockfile
- ✅ `npm run build` succeeds with vite 8.0.16 on Node 20
